### PR TITLE
[codex] release 0.2.8

### DIFF
--- a/flexdblink-maven-plugin/pom.xml
+++ b/flexdblink-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.yok</groupId>
         <artifactId>flexdblink-parent</artifactId>
-        <version>0.2.7</version>
+        <version>0.2.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.github.yok</groupId>
             <artifactId>flexdblink</artifactId>
-            <version>0.2.7</version>
+            <version>0.2.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/flexdblink/pom.xml
+++ b/flexdblink/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.github.yok</groupId>
 		<artifactId>flexdblink-parent</artifactId>
-		<version>0.2.7</version>
+		<version>0.2.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>flexdblink</artifactId>
@@ -17,7 +17,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -271,6 +275,14 @@
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<relocations>
 								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.dbunit</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.dbunit</shadedPattern>
+								</relocation>
+								<relocation>
 									<pattern>org.apache.commons.csv</pattern>
 									<shadedPattern>io.github.yok.flexdblink.shaded.csv</shadedPattern>
 								</relocation>
@@ -293,6 +305,22 @@
 								<relocation>
 									<pattern>org.yaml.snakeyaml</pattern>
 									<shadedPattern>io.github.yok.flexdblink.shaded.snakeyaml</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.codec</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.codec</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google.errorprone</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.errorprone</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google.j2objc</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.j2objc</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.jspecify</pattern>
+									<shadedPattern>io.github.yok.flexdblink.shaded.jspecify</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.yok</groupId>
 	<artifactId>flexdblink-parent</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<packaging>pom</packaging>
 	<name>FlexDBLink Parent</name>
 	<description>Manage DB test data as text (CSV/JSON/YAML/XML ↔ DB), with LOB files and JUnit 5 + Spring integration for Oracle/PostgreSQL/MySQL/SQL Server.</description>


### PR DESCRIPTION
## Summary
- replace `spring-boot-starter` with `spring-boot` and `spring-boot-autoconfigure` in `flexdblink`
- bump the project version from `0.2.7` to `0.2.8` across the parent, core module, and Maven plugin

## Why
The core test-support artifact was leaking Boot starter logging dependencies into consumer test classpaths. This release keeps the Boot APIs that `Main` and the Spring-based JUnit extension need, while avoiding the transitive logging bundle from `spring-boot-starter`.

## Impact
Consumers using `io.github.yok:flexdblink:0.2.8` should no longer pick up `spring-boot-starter-logging`, `logback-classic`, `log4j-to-slf4j`, or `jul-to-slf4j` through this dependency.

## Root Cause
`flexdblink` packaged CLI support and Spring-based test support in the same artifact and declared `spring-boot-starter` as a compile dependency, which pulled the starter logging stack into downstream test execution.

## Validation
- `mvn clean test`
- `mvn -B -DskipTests install -pl flexdblink`
- `mvn -B clean verify -pl flexdblink-maven-plugin`
- verified the compile dependency tree only retains `spring-boot` and `spring-boot-autoconfigure` for the Boot runtime pieces